### PR TITLE
Fix expansion and stringization of PROJECT_ROOT_DIR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,7 +178,7 @@ model {
   binaries {
     withType(NativeBinarySpec).all {
       nativeUtils.useRequiredLibrary(it, "gui")
-      it.cppCompiler.define("PROJECT_ROOT_DIR", "\"$projectDir\"")
+      it.cppCompiler.define("PROJECT_ROOT_DIR", "$projectDir")
       // Add platform-specific renderer dependencies.
       if (it.targetPlatform.operatingSystem.isWindows()) {
         it.linker.args << 'Gdi32.lib' << 'Shell32.lib' << 'd3d11.lib' << 'd3dcompiler.lib'

--- a/project_utils/cpp/generation/SysIdSetup.cpp
+++ b/project_utils/cpp/generation/SysIdSetup.cpp
@@ -22,7 +22,7 @@ wpi::json GetConfigJson() {
 #ifdef PROJECT_ROOT_DIR
 // TODO: Fix problems with this so that we don't need this ifdef
 #ifdef INTEGRATION
-    os << PROJECT_ROOT_DIR << "/src/main/deploy/" << filename;
+    os << EXPAND_STRINGIZE(PROJECT_ROOT_DIR) << "/src/main/deploy/" << filename;
 #endif
 #endif
   } else {

--- a/project_utils/include/generation/SysIdSetup.h
+++ b/project_utils/include/generation/SysIdSetup.h
@@ -23,6 +23,10 @@
 #define PATH_SEPARATOR "/"
 #endif
 
+// Based on https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html
+#define EXPAND_STRINGIZE(s) STRINGIZE(s)
+#define STRINGIZE(s) #s
+
 constexpr const char* filename = "config.json";
 
 wpi::json GetConfigJson();

--- a/src/integrationtest/native/cpp/GenerationTest.cpp
+++ b/src/integrationtest/native/cpp/GenerationTest.cpp
@@ -49,7 +49,8 @@ class GenerationTest : public ::testing::Test {
     wpi::SmallString<128> path;
     wpi::raw_svector_ostream os(path);
 
-    os << PROJECT_ROOT_DIR << SYSID_PATH_SEPARATOR << directory;
+    os << EXPAND_STRINGIZE(PROJECT_ROOT_DIR) << SYSID_PATH_SEPARATOR
+       << directory;
 
     m_directory = path.c_str();
 

--- a/src/integrationtest/native/cpp/SimulationTest.cpp
+++ b/src/integrationtest/native/cpp/SimulationTest.cpp
@@ -55,7 +55,7 @@ class IntegrationTest : public ::testing::Test {
     wpi::SmallString<128> cmd;
     wpi::raw_svector_ostream os(cmd);
 
-    os << "cd " << PROJECT_ROOT_DIR << SYSID_PATH_SEPARATOR
+    os << "cd " << EXPAND_STRINGIZE(PROJECT_ROOT_DIR) << SYSID_PATH_SEPARATOR
        << "integration_test_project"
        << " && " << LAUNCHSIM << " -Pintegration";
     wpi::outs() << "Executing: " << cmd.c_str() << "\n";
@@ -94,7 +94,7 @@ class IntegrationTest : public ::testing::Test {
 
   void TearDown() override {
     // Save the JSON and make sure that everything checks out.
-    auto path = m_manager->SaveJSON(PROJECT_ROOT_DIR);
+    auto path = m_manager->SaveJSON(EXPAND_STRINGIZE(PROJECT_ROOT_DIR));
     try {
       auto analyzerSettings = sysid::AnalysisManager::Settings{};
       analyzerSettings.windowSize = 15;
@@ -140,7 +140,8 @@ class IntegrationTest : public ::testing::Test {
                            // upload
         wpi::SmallString<128> jsonFolderPath;
         wpi::raw_svector_ostream os(jsonFolderPath);
-        os << PROJECT_ROOT_DIR << SYSID_PATH_SEPARATOR << "jsons/";
+        os << EXPAND_STRINGIZE(PROJECT_ROOT_DIR) << SYSID_PATH_SEPARATOR
+           << "jsons/";
 
         wpi::SmallString<128> failCommand;
         wpi::raw_svector_ostream cmdOs(failCommand);

--- a/src/main/native/build_files/general.txt
+++ b/src/main/native/build_files/general.txt
@@ -92,7 +92,7 @@ model {
             wpi.deps.wpilib(it)
 
             binaries.all {
-              it.cppCompiler.define("PROJECT_ROOT_DIR", "\"$projectDir\"")
+              it.cppCompiler.define("PROJECT_ROOT_DIR", "$projectDir")
               if (project.hasProperty("integration")) {
                 it.cppCompiler.define("INTEGRATION")
               }

--- a/src/main/native/build_files/romi.txt
+++ b/src/main/native/build_files/romi.txt
@@ -98,7 +98,7 @@ model {
             wpi.deps.wpilib(it)
 
             binaries.all {
-              it.cppCompiler.define("PROJECT_ROOT_DIR", "\"$projectDir\"")
+              it.cppCompiler.define("PROJECT_ROOT_DIR", "$projectDir")
               if (project.hasProperty("integration")) {
                 it.cppCompiler.define("INTEGRATION")
               }

--- a/src/main/native/cpp/generation/ConfigManager.cpp
+++ b/src/main/native/cpp/generation/ConfigManager.cpp
@@ -110,8 +110,8 @@ void ConfigManager::SaveJSON(wpi::StringRef path, size_t portCount,
 
   wpi::SmallString<128> gradleInPath;
   wpi::raw_svector_ostream gradleIn{gradleInPath};
-  gradleIn << PROJECT_ROOT_DIR << SYSID_PATH_SEPARATOR << m_gradlePath
-           << (isRomi ? "romi.txt" : "general.txt");
+  gradleIn << EXPAND_STRINGIZE(PROJECT_ROOT_DIR) << SYSID_PATH_SEPARATOR
+           << m_gradlePath << (isRomi ? "romi.txt" : "general.txt");
 
   wpi::SmallString<128> gradleOutPath;
   wpi::raw_svector_ostream gradleOut{gradleOutPath};

--- a/src/main/native/include/sysid/Util.h
+++ b/src/main/native/include/sysid/Util.h
@@ -28,6 +28,10 @@
 #define LAUNCHSIM "./gradlew simulateCpp"
 #endif
 
+// Based on https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html
+#define EXPAND_STRINGIZE(s) STRINGIZE(s)
+#define STRINGIZE(s) #s
+
 namespace sysid {
 static constexpr const char* kUnits[] = {"Meters",  "Feet",      "Inches",
                                          "Radians", "Rotations", "Degrees"};


### PR DESCRIPTION
The original PROJECT_ROOT_DIR definition didn't encode correctly as a
double quoted string in the JSON, so clang wasn't expanding the macro in
source code as a string.